### PR TITLE
Removed duplicate <head> tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,3 @@
-<head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,4 +18,3 @@
 
 	  gtag('config', 'UA-2202603-1');
 	</script>
-</head>


### PR DESCRIPTION
I find this profusion of tag disturbing<sup>[[1]](https://pics.me.me/i-find-your-lack-of-faith-disturbing-16786928.png)</sup>.

If you prefer remove the [other one](https://github.com/iprignano/ivanprignano/blob/master/_layouts/default.html), but do something!